### PR TITLE
Add SPI shields to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Y—Network](https://user-images.githubusercontent.com/1037520/202389911-bd44883e-aa11-4584-9f78-3934ef1b4bf2.jpeg)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fyml-org%2Fynetwork-ios%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/yml-org/ynetwork-ios) [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fyml-org%2Fynetwork-ios%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/yml-org/ynetwork-ios)  
 _A networking layer for iOS and tvOS._
 
 🤖 Looking for the Android version? Check it out [here](https://github.com/yml-org/ynetwork-android).


### PR DESCRIPTION
## Introduction ##

Our other open source iOS repo's have shields indicating Swift version compatibility and platform compatibility. We should add the same to Y—Network.

## Purpose ##

Add the two shields to the README
Resolves #1 

## Scope ##

* update README

## 📱 Screenshots ##

<img width="1190" alt="image" src="https://user-images.githubusercontent.com/1037520/203092422-872b50d9-c232-44ad-8a58-f540b69e7743.png">

## 📈 Coverage ##

Should be unchanged