### PR TITLE
[CM-998] Add new linter rules and fix warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,6 +9,8 @@ opt_in_rules: # some rules are turned off by default, so you need to opt-in
   - empty_count
   - first_where
   - force_unwrapping
+  - implicit_return
+  - missing_docs
   - multiline_arguments
   - multiline_arguments_brackets
   - multiline_function_chains
@@ -24,6 +26,8 @@ opt_in_rules: # some rules are turned off by default, so you need to opt-in
 
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Pods
+  - docs
+  - .build
 
 # configurable rules can be customized from this configuration file
 # binary rules can set their severity level

--- a/.swiftpm/xcode/xcshareddata/xcschemes/YNetwork.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/YNetwork.xcscheme
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1410"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "YNetwork_YNetworkTests"
+               BuildableName = "YNetwork_YNetworkTests"
+               BlueprintName = "YNetwork_YNetworkTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "YNetwork"
+               BuildableName = "YNetwork"
+               BlueprintName = "YNetwork"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "YNetworkTests"
+               BuildableName = "YNetworkTests"
+               BlueprintName = "YNetworkTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "YNetworkTests"
+               BuildableName = "YNetworkTests"
+               BlueprintName = "YNetworkTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "YNetwork_YNetworkTests"
+            BuildableName = "YNetwork_YNetworkTests"
+            BlueprintName = "YNetwork_YNetworkTests"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/YNetwork/Core/Extensions/String+regex.swift
+++ b/Sources/YNetwork/Core/Extensions/String+regex.swift
@@ -14,7 +14,7 @@ extension String {
     /// - Parameter pattern: the regular expression pattern to evaluate
     /// - Returns: `true` if the string matches the pattern, otherwise `false`.
     public func matches(regex pattern: String) -> Bool {
-        return self.range(
+        range(
             of: pattern,
             options: .regularExpression,
             range: nil,

--- a/Sources/YNetwork/Extensions/String+isAbsoluteURLPath.swift
+++ b/Sources/YNetwork/Extensions/String+isAbsoluteURLPath.swift
@@ -15,6 +15,6 @@ let kUrlSchemaRegex = "^(ht|f)tp(s?)\\:\\/\\/"
 extension String {
     /// Determines whether the string begins with `http://`, `https://`, `ftp://`, or `ftps://`
     public var isAbsoluteURLPath: Bool {
-        return self.matches(regex: kUrlSchemaRegex)
+        matches(regex: kUrlSchemaRegex)
     }
 }

--- a/Sources/YNetwork/Models/JWT/JWTToken.swift
+++ b/Sources/YNetwork/Models/JWT/JWTToken.swift
@@ -10,9 +10,13 @@ import Foundation
 
 /// JWT token.
 public struct JWTToken {
+    /// JWT token header
     public let header: [String: Any]
+    /// JWT token body
     public let body: [String: Any]
+    /// JWT token signature
     public let signature: String?
+    /// Original JWT token string
     public let string: String
     
     /// public init method

--- a/Sources/YNetwork/NetworkManager/NetworkManager.swift
+++ b/Sources/YNetwork/NetworkManager/NetworkManager.swift
@@ -30,7 +30,7 @@ open class NetworkManager: NSObject {
     @available(iOS 14.0, tvOS 14.0, *)
     open var logger: Logger? {
         get {
-            return _logger as? Logger
+            _logger as? Logger
         } set {
             _logger = newValue
         }

--- a/Sources/YNetwork/Protocols/MultipartRequest.swift
+++ b/Sources/YNetwork/Protocols/MultipartRequest.swift
@@ -18,9 +18,14 @@ public protocol MultipartRequest: NetworkRequest {
 
 /// Default implementation for Multipart Request properties.
 public extension MultipartRequest {
+    /// Uses `.POST` HTTP method
     var method: HttpMethod { .POST }
+
+    /// Sets `.multipart` as request content type
     var requestType: RequestContentType {
         .multipart(boundary: multipart.boundary)
     }
+
+    /// Sets the `multipart` builder as the body
     var body: BodyBuilder? { multipart }
 }

--- a/Sources/YNetwork/Protocols/NetworkRequest.swift
+++ b/Sources/YNetwork/Protocols/NetworkRequest.swift
@@ -79,25 +79,36 @@ public protocol NetworkRequest {
 /// Default implementation for Network Request properties.
 /// The only required property to implement is `path`. Everything else has default values.
 public extension NetworkRequest {
+    /// Uses no base path
     var basePath: PathRepresentable? { nil }
 
+    /// Uses `.GET` HTTP method
     var method: HttpMethod { .GET }
 
+    /// Includes no additional headers
     var headers: HttpHeaders? { nil }
 
+    /// Sets `.JSON` as request content type
     var requestType: RequestContentType { .JSON }
 
+    /// Sets `.JSON` as response content type
     var responseType: ResponseContentType { .JSON }
 
+    /// No query parameters
     var queryParameters: ParametersBuilder? { nil }
 
+    /// No body
     var body: BodyBuilder? { nil }
 
+    /// Uses the default timeout interval
     var timeoutInterval: TimeInterval { 0 }
 
+    /// Uses the default cache policy
     var cachePolicy: URLRequest.CachePolicy? { nil }
-    
+
+    /// Uses the default parser factory
     var parserFactory: DataParserFactory? { nil }
 
+    /// Uses session tokens (if `NetworkManager.sessionManager` is specified)
     var usesSession: Bool { true }
 }

--- a/Tests/YNetworkTests/NetworkManager/Helpers/MockURLNetworkEngine.swift
+++ b/Tests/YNetworkTests/NetworkManager/Helpers/MockURLNetworkEngine.swift
@@ -37,11 +37,11 @@ final class MockURLNetworkEngine: URLNetworkEngine {
     }
 
     override func submitBackgroundDownload(_ request: URLRequest) throws -> Cancelable {
-        return MockURLSessionTask()
+        MockURLSessionTask()
     }
 
     override func submitBackgroundUpload(_ request: URLRequest, fileUrl: URL) throws -> Cancelable {
-        return MockURLSessionTask()
+        MockURLSessionTask()
     }
 }
 

--- a/Tests/YNetworkTests/NetworkManager/URLBuilderTests.swift
+++ b/Tests/YNetworkTests/NetworkManager/URLBuilderTests.swift
@@ -9,6 +9,9 @@
 import XCTest
 @testable import YNetwork
 
+// Large tuples help us build unit test expectations concisely
+// swiftlint:disable large_tuple
+
 typealias PathTestCase = (basePath: PathTestUrl?, path: String, output: String)
 typealias FormUrlTestCase = (key: String, value: Any, output: String?)
 typealias QueryTestCase = (params: Parameters, output: String)


### PR DESCRIPTION
## Introduction
Our style guide requires the use of implicit return and our library team requires full documentation, so we should add linter rules to enforce these things instead of having to spot them during code review.

## Purpose
Update SwiftLint config with `implicit_return` and `missing_docs` rules. Fix any linter violations.

## Scope
* Update `.swiftlint.yml`
* Fix linter violations

## Discussion
YNetwork had violations of both rules. There’s also a new change in how SwiftLint enforces the large_tuple rule. I just disabled it for the unit tests in question. (Not worth declaring specialty struct’s in this case in my opinion.) 

I also enabled the gathering of code coverage from unit tests (the `.xcscheme` file) because that had been missing.

We want to roll out these changes to all of our YML libraries, both in Bitbucket and on GitHub.

Fixes Issue #53 

## 📈 Coverage
Unchanged. And documentation coverage should now be enforced by the linter!
