### PR TITLE
[Issue-7] Update SwiftLint config file to latest

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,7 +4,6 @@ disabled_rules: # rule identifiers turned on by default to exclude from running
   - multiple_closures_with_trailing_closure
 
 opt_in_rules: # some rules are turned off by default, so you need to opt-in
-  - anyobject_protocol
   - contains_over_first_not_nil
   - empty_count
   - first_where
@@ -20,7 +19,6 @@ opt_in_rules: # some rules are turned off by default, so you need to opt-in
   - operator_whitespace
   - prohibited_interface_builder
   - unneeded_parentheses_in_closure_argument
-  - unused_import
   - vertical_whitespace_closing_braces
   - vertical_whitespace_opening_braces
 

--- a/Tests/YNetworkTests/NetworkManager/NetworkManagerUploadTests.swift
+++ b/Tests/YNetworkTests/NetworkManager/NetworkManagerUploadTests.swift
@@ -71,7 +71,7 @@ final class NetworkManagerUploadTests: XCTestCase {
         let task = try XCTUnwrap(sut.submitBackgroundUpload(request) { _ in })
         task.cancel() // this will make it fail
 
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: timeout)
 
         XCTAssertNotNil(sut.receivedError)
     }
@@ -176,7 +176,9 @@ private final class NetworkManagerSpy: NetworkManager {
             if let httpResponse = task.response as? HTTPURLResponse {
                 switch httpResponse.statusCode {
                 case 200..<300:
-                    break
+                    if task.state == .canceling {
+                        error = NetworkSpyError.cancelled
+                    }
                 case 401:
                     error = NetworkError.unauthenticated
                 default:
@@ -211,4 +213,8 @@ extension NetworkManagerSpy: URLSessionDataDelegate {
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         self.receivedData = data
     }
+}
+
+public enum NetworkSpyError: Error {
+    case cancelled
 }


### PR DESCRIPTION
## Introduction ##

We've (relatively) recently removed a couple of unused rules from our SwiftLint config. All our projects should be brought up to date to use the same configuration.

## Purpose ##

Update the SwiftLint config file to the latest. Resolve any linter warnings that might arise.
Fix #7 

## Scope ##

Update `.swiftlint.yml`

## 📈 Coverage ##

Code and documentation coverage should both remain unchanged.