### PR TITLE
[Issue-9] Fix flaky unit test

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/YNetwork.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/YNetwork.xcscheme
@@ -58,7 +58,8 @@
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "YNetworkTests"

--- a/Sources/YNetwork/NetworkManager/Mock/URLProtocolStubNetworkEngine.swift.swift
+++ b/Sources/YNetwork/NetworkManager/Mock/URLProtocolStubNetworkEngine.swift.swift
@@ -13,6 +13,13 @@ final public class URLProtocolStubNetworkEngine: NetworkEngine {
     private(set) var session: URLSession!
     internal let protocolClasses: [AnyClass]
 
+    /// Whether created background upload and download tasks should be autoresumed.
+    /// Default = `true`.
+    ///
+    /// For unit testing it is sometimes useful to set this to `false` and manually call `resume()`
+    /// on the `URLSessionTask` returned from the submit methods.
+    public var autoResumesBackgroundTasks: Bool = true
+
     /// Initializes an URLProtocolStubNetworkEngine with protocolClasses
     /// - Parameter protocolClasses: URLProtocol class that need to be stub
     /// default class will be URLProtocolStub
@@ -75,7 +82,9 @@ final public class URLProtocolStubNetworkEngine: NetworkEngine {
         // make a URLSessionDownloadTask, resume it, then return it
         let downloadTask = session.downloadTask(with: request)
         downloadTask.taskDescription = "\(request: request)"
-        downloadTask.resume()
+        if autoResumesBackgroundTasks {
+            downloadTask.resume()
+        }
         return downloadTask
     }
 
@@ -100,7 +109,9 @@ final public class URLProtocolStubNetworkEngine: NetworkEngine {
         // make a URLSessionUploadTask, resume it, then return it
         let uploadTask = session.uploadTask(with: request, from: data)
         uploadTask.taskDescription = "\(request: request)"
-        uploadTask.resume()
+        if autoResumesBackgroundTasks {
+            uploadTask.resume()
+        }
         return uploadTask
     }
 }

--- a/Tests/YNetworkTests/NetworkManager/NetworkManagerDownloadTests.swift
+++ b/Tests/YNetworkTests/NetworkManager/NetworkManagerDownloadTests.swift
@@ -130,6 +130,9 @@ final class NetworkManagerDownloadTests: XCTestCase {
 
         let engine = try XCTUnwrap(sut.configuration?.networkEngine as? URLProtocolStubNetworkEngine)
         engine.autoResumesBackgroundTasks = false
+        defer {
+            engine.autoResumesBackgroundTasks = true
+        }
 
         URLProtocolStub.appendStub(withData: makeData(), statusCode: 200, type: .download)
 
@@ -139,7 +142,7 @@ final class NetworkManagerDownloadTests: XCTestCase {
         task.cancel() // this will make it fail
         task.resume() // resume it
 
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: timeout)
 
         XCTAssertNotNil(sut.receivedError)
     }

--- a/Tests/YNetworkTests/NetworkManager/NetworkManagerUploadTests.swift
+++ b/Tests/YNetworkTests/NetworkManager/NetworkManagerUploadTests.swift
@@ -66,6 +66,9 @@ final class NetworkManagerUploadTests: XCTestCase {
 
         let engine = try XCTUnwrap(sut.configuration?.networkEngine as? URLProtocolStubNetworkEngine)
         engine.autoResumesBackgroundTasks = false
+        defer {
+            engine.autoResumesBackgroundTasks = true
+        }
 
         URLProtocolStub.appendStub(withData: data, statusCode: 200, type: .upload)
 

--- a/Tests/YNetworkTests/NetworkManager/NetworkManagerUploadTests.swift
+++ b/Tests/YNetworkTests/NetworkManager/NetworkManagerUploadTests.swift
@@ -64,12 +64,16 @@ final class NetworkManagerUploadTests: XCTestCase {
         let expectation = expectation(description: "Wait for upload failure.")
         sut.expectation = expectation
 
+        let engine = try XCTUnwrap(sut.configuration?.networkEngine as? URLProtocolStubNetworkEngine)
+        engine.autoResumesBackgroundTasks = false
+
         URLProtocolStub.appendStub(withData: data, statusCode: 200, type: .upload)
 
         XCTAssertNil(sut.receivedError)
 
-        let task = try XCTUnwrap(sut.submitBackgroundUpload(request) { _ in })
+        let task = try XCTUnwrap(sut.submitBackgroundUpload(request) { _ in } as? URLSessionTask)
         task.cancel() // this will make it fail
+        task.resume() // resume it
 
         wait(for: [expectation], timeout: timeout)
 


### PR DESCRIPTION
## Introduction ##

Recently we've had one flaky unit test that's been acting up. We should fix its behavior.

## Purpose ##

Fix #9 flaky unit test (testing behavior of cancel on background upload request).

## Scope ##

* Add variable to `URLProtocolStubNetworkEngine` to turn off automatically resuming background tasks immediately after submitting them.
* Modify cancel test for background upload task
* Modify cancel test for background download task

## Discussion ##

The download manager cancel test had not (yet) been flaky, but we should probably adopt the same behavior for both tests.
I also set the tests to execute in random order (this should already have been the case).

## 📈 Coverage ##

##### Code #####

94.4%

<img width="555" alt="image" src="https://user-images.githubusercontent.com/1037520/224735310-a683f387-36cc-48c9-9969-dab8dea2a683.png">

##### Documentation #####

100%

<img width="405" alt="image" src="https://user-images.githubusercontent.com/1037520/224735575-fef1fd11-ef5a-4ed7-ac72-48f0fc01c7ce.png">
