### PR TITLE
[ISSUE] Remove Swift 5.8 warning

### DIFF
--- a/Tests/YNetworkTests/TestHelpers/Request/GetTriviaRequest.swift
+++ b/Tests/YNetworkTests/TestHelpers/Request/GetTriviaRequest.swift
@@ -47,7 +47,7 @@ extension TriviaResponse {
                     "question": "Which river flows through the Scottish city of Glasgow?",
                     "correct_answer": "Clyde",
                     "incorrect_answers": ["Tay", "Dee", "Tweed"]
-                ], [
+                ] as [String: Any], [
                     "category": "General Knowledge",
                     "type": "multiple",
                     "difficulty": "medium",


### PR DESCRIPTION
## Introduction ##

```warning:Heterogeneous collection literal could only be inferred to '[String : Any]' add explicit type annotation if this is intentional```
Remove this warning.
## Purpose ##

Swift5.8 introduced a new warning.
Fix https://github.com/yml-org/ynetwork-ios/issues/15
## Scope ##

Update this file `GetTriviaRequest.swift`.
## Out of Scope ##

Any functionality or UI changes.

## 📈 Coverage ##

##### Code #####

No change.

##### Documentation #####

No change.