### PR TITLE
Issue 18 - Adding Upload Completion Handler for Handling Custom/Error…

### DIFF
--- a/Sources/YNetwork/NetworkManager/NetworkManager+URLSessionTaskDelegate.swift
+++ b/Sources/YNetwork/NetworkManager/NetworkManager+URLSessionTaskDelegate.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - URLSessionTaskDelegate
 
-extension NetworkManager: URLSessionTaskDelegate {
+extension NetworkManager: URLSessionTaskDelegate, URLSessionDataDelegate {
     /// :nodoc:
     public func urlSession(
         _ session: URLSession,
@@ -38,6 +38,17 @@ extension NetworkManager: URLSessionTaskDelegate {
             fileDownload.urlSession(session, task: task, didCompleteWithError: error)
         } else if task is URLSessionUploadTask {
             fileUpload.urlSession(session, task: task, didCompleteWithError: error)
+        }
+    }
+    
+    /// :nodoc:
+    public func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive data: Data
+    ) {
+        if dataTask is URLSessionUploadTask {
+            fileUpload.urlSession(session, dataTask: dataTask, didReceive: data)
         }
     }
 }

--- a/Sources/YNetwork/NetworkManager/NetworkManager.swift
+++ b/Sources/YNetwork/NetworkManager/NetworkManager.swift
@@ -161,11 +161,12 @@ open class NetworkManager: NSObject {
     /// - Parameters:
     ///   - request: the upload network request to submit
     ///   - progress: progress handler (will be called back on main thread)
+    ///   - completionHandler: file upload handler (will be called back on URLSession background thread).
     /// - Returns: a cancelable upload task if one was able to be created, otherwise nil if no task was issued
     @discardableResult open func submitBackgroundUpload(
         _ request: NetworkRequest,
         progress: ProgressHandler? = nil,
-        completion: CompletionHandler? = nil
+        completionHandler: FileUploadHandler? = nil
     ) -> Cancelable? {
         guard let urlRequest = try? buildUrlRequest(request: request) else { return nil }
 
@@ -179,7 +180,7 @@ open class NetworkManager: NSObject {
 
         // creating the upload task copies the file
         let task = try? configuration?.networkEngine.submitBackgroundUpload(urlRequest, fileUrl: localURL)
-        fileUpload.register(task, progress: progress, completion: completion)
+        fileUpload.registerUpload(task, progress: progress, completion: completionHandler)
         return task
     }
     

--- a/Sources/YNetwork/NetworkManager/NetworkManager.swift
+++ b/Sources/YNetwork/NetworkManager/NetworkManager.swift
@@ -164,7 +164,8 @@ open class NetworkManager: NSObject {
     /// - Returns: a cancelable upload task if one was able to be created, otherwise nil if no task was issued
     @discardableResult open func submitBackgroundUpload(
         _ request: NetworkRequest,
-        progress: ProgressHandler? = nil
+        progress: ProgressHandler? = nil,
+        completion: CompletionHandler? = nil
     ) -> Cancelable? {
         guard let urlRequest = try? buildUrlRequest(request: request) else { return nil }
 
@@ -178,7 +179,7 @@ open class NetworkManager: NSObject {
 
         // creating the upload task copies the file
         let task = try? configuration?.networkEngine.submitBackgroundUpload(urlRequest, fileUrl: localURL)
-        fileUpload.register(task, progress: progress)
+        fileUpload.register(task, progress: progress, completion: completion)
         return task
     }
     

--- a/Sources/YNetwork/NetworkManager/Progress/FileUploadProgress.swift
+++ b/Sources/YNetwork/NetworkManager/Progress/FileUploadProgress.swift
@@ -39,6 +39,6 @@ extension FileUploadProgress: URLSessionTaskDelegate, URLSessionDataDelegate {
     ) {
         // clean up the task now that the final response for the upload was received
         receive(data: data, forKey: dataTask.taskIdentifier)
-        unregisterCompletion(forKey: dataTask.taskIdentifier)
+        unregisterUploadCompletion(forKey: dataTask.taskIdentifier)
     }
 }

--- a/Sources/YNetwork/NetworkManager/Progress/FileUploadProgress.swift
+++ b/Sources/YNetwork/NetworkManager/Progress/FileUploadProgress.swift
@@ -15,7 +15,7 @@ import Foundation
 /// to optionally track progress for large file upload tasks.
 internal class FileUploadProgress: FileProgress { }
 
-extension FileUploadProgress: URLSessionTaskDelegate {
+extension FileUploadProgress: URLSessionTaskDelegate, URLSessionDataDelegate {
     func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
@@ -30,5 +30,15 @@ extension FileUploadProgress: URLSessionTaskDelegate {
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         // clean up the task now that we're finished with it
         unregister(forKey: task.taskIdentifier)
+    }
+    
+    public func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive data: Data
+    ) {
+        // clean up the task now that the final response for the upload was received
+        receive(data: data, forKey: dataTask.taskIdentifier)
+        unregisterCompletion(forKey: dataTask.taskIdentifier)
     }
 }

--- a/Tests/YNetworkTests/NetworkManager/NetworkManagerUploadTests.swift
+++ b/Tests/YNetworkTests/NetworkManager/NetworkManagerUploadTests.swift
@@ -74,7 +74,7 @@ final class NetworkManagerUploadTests: XCTestCase {
 
         XCTAssertNil(sut.receivedError)
 
-        let task = try XCTUnwrap(sut.submitBackgroundUpload(request) { _ in } as? URLSessionTask)
+        let task = try XCTUnwrap(sut.submitBackgroundUpload(request, completionHandler:  { _ in }) as? URLSessionTask)
         task.cancel() // this will make it fail
         task.resume() // resume it
 
@@ -90,7 +90,7 @@ final class NetworkManagerUploadTests: XCTestCase {
         XCTAssertNil(sut.receivedError)
 
         URLProtocolStub.appendStub(.failure(NetworkError.invalidResponse), type: .upload)
-        let task = sut.submitBackgroundUpload(request) { _ in }
+        let task = sut.submitBackgroundUpload(request, completionHandler:  { _ in })
 
         XCTAssertNotNil(task)
 
@@ -154,7 +154,7 @@ final class NetworkManagerUploadTests: XCTestCase {
         let sut = NetworkManager()
 
         // Given we submit a request without first configuring the network manager
-        let task = sut.submitBackgroundUpload(request) { _ in }
+        let task = sut.submitBackgroundUpload(request, completionHandler:  { _ in })
 
         // We don't expect a task to be returned
         XCTAssertNil(task)
@@ -209,16 +209,14 @@ private final class NetworkManagerSpy: NetworkManager {
             self.fulfill()
         }
     }
+    
+    override func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        self.receivedData = data
+    }
 
     func fulfill() {
         expectation?.fulfill()
         expectation = nil
-    }
-}
-
-extension NetworkManagerSpy: URLSessionDataDelegate {
-    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        self.receivedData = data
     }
 }
 


### PR DESCRIPTION
## Introduction ##

There is no code in the library to handle the response received after uploading a file. The response is simply discarded. This might acceptable for some uploads, but if you're expecting a custom response or error that you need to react to after an upload attempt then you need to capture the response and provide it to the app using this library.

## Purpose ##

The purpose of this PR is to add a completion handler to be used with the submitBackgroundUpload API. This will allow the library to use a the URLSessionDataDelegate to receive the response and pass it to the provided completion handler from the app using the library.

## Scope ##

The FileUploadProgress component has been updated to also use the URLSessionDataDelegate so that it can receive the final response after uploading a file. This response will then be provided to the completion handler associated with the background task identifier.

## Issue Link ##
https://github.com/codeandtheory/ynetwork-ios/issues/18 : Background Upload Completion Handler Missing for Response